### PR TITLE
Fix texture loader to support non-basic materials

### DIFF
--- a/at_planetarium/src/ts/CelestialBody.ts
+++ b/at_planetarium/src/ts/CelestialBody.ts
@@ -109,7 +109,15 @@ private loadTexture(): void {
         this.data.textureUrl,
         (texture) => {
           this.texture = texture;
-          if (this.mesh.material instanceof THREE.MeshBasicMaterial) {
+          // Support multiple material types that can receive textures.
+          // The original implementation only updated the map when the
+          // material was `MeshBasicMaterial`, but most bodies use
+          // `MeshPhongMaterial`, so textures were never applied.
+          if (
+            this.mesh &&
+            (this.mesh.material instanceof THREE.MeshBasicMaterial ||
+             this.mesh.material instanceof THREE.MeshPhongMaterial)
+          ) {
             this.mesh.material.map = this.texture;
             this.mesh.material.needsUpdate = true;
           }


### PR DESCRIPTION
## Summary
- ensure CelestialBody applies loaded textures to both MeshBasicMaterial and MeshPhongMaterial
- guard against race conditions when applying texture before mesh exists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: TS errors: OrbitData declared but never used, ... Argument of type 'number' is not assignable to parameter of type 'string')

------
https://chatgpt.com/codex/tasks/task_e_689deda594648328875222d801aba28e