### PR TITLE
fix: correct text converter name

### DIFF
--- a/FNH_JP_Weather/js/main.js
+++ b/FNH_JP_Weather/js/main.js
@@ -32,14 +32,14 @@ function weatherDataConverter(regionName, JSONdataArray, areanum){
     const areaWeather = weatherCase(areaCode);
 
     const text = regionName + '地方：' + areaWeather + ' ／ ' ;
-    const newtext = textConveter(text);
+    const newtext = textConverter(text);
     const node = document.createElement('span');
     node.innerHTML = newtext;
     document.getElementById('weather').appendChild(node);
 
 }
 
-function textConveter(text){
+function textConverter(text){
     const laterReplace = text.replace('後', ' ⇒ ');
     const partlyReplace = laterReplace.replace('時々', '｜');
     const onceReplace = partlyReplace.replace('一時', '｜');


### PR DESCRIPTION
## Summary
- rename textConveter function and its calls to textConverter

## Testing
- `node --check FNH_JP_Weather/js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dee74a6948328951e4925033cb344