### PR TITLE
docs: clarify marquee speed setting

### DIFF
--- a/FNH_JP_Weather/README.md
+++ b/FNH_JP_Weather/README.md
@@ -1,0 +1,10 @@
+# FNH JP Weather
+
+The marquee text animation speed is controlled in `js/main.js`:
+
+```javascript
+var time = marqueeWidth / 20; // Change 20 to adjust speed
+```
+
+Adjust the `20` value to modify the scroll speed. Lower numbers produce slower scrolling, while higher numbers make it faster.
+

--- a/FNH_JP_Weather/js/main.js
+++ b/FNH_JP_Weather/js/main.js
@@ -92,7 +92,7 @@ function weatherCase(weatherCode){
 function setMarqueeAnimationTime() {
     var marquee = document.querySelector('.animation');
     var marqueeWidth = marquee.offsetWidth;
-    var time = marqueeWidth / 20; // Change 50 to adjust speed
+    var time = marqueeWidth / 20; // Change 20 to adjust speed
     marquee.style.animationDuration = time + 's';
   }
   


### PR DESCRIPTION
## Summary
- fix marquee animation comment to reference the correct 20 speed divisor
- document marquee speed constant in new FNH_JP_Weather README

## Testing
- `(cd FNH_JP_Weather && npm test)` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dee764920832880a96083be43ee2d