### PR TITLE
feat: support texture loading for generic materials

### DIFF
--- a/at_planetarium/src/ts/CelestialBody.ts
+++ b/at_planetarium/src/ts/CelestialBody.ts
@@ -109,8 +109,13 @@ private loadTexture(): void {
         this.data.textureUrl,
         (texture) => {
           this.texture = texture;
-          if (this.mesh.material instanceof THREE.MeshBasicMaterial) {
-            this.mesh.material.map = this.texture;
+          if (
+            this.mesh.material instanceof THREE.Material &&
+            'map' in this.mesh.material
+          ) {
+            (this.mesh.material as THREE.Material & {
+              map: THREE.Texture | null;
+            }).map = this.texture;
             this.mesh.material.needsUpdate = true;
           }
         },


### PR DESCRIPTION
## Summary
- allow CelestialBody to apply textures to any material type supporting `map`

## Testing
- `node node_modules/typescript/bin/tsc` *(fails: OrbitData is declared but never used; isOrbitVisible is declared but its value is never read; updateTagScale is declared but its value is never read; needsRender is declared but its value is never read; Argument of type 'number' is not assignable to parameter of type 'string')*


------
https://chatgpt.com/codex/tasks/task_e_689dee7585048328a72df8d1f2cc1a0a